### PR TITLE
ci: add workflow_dispatch trigger to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,7 @@
 name: Documentation
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the docs workflow so it can be manually triggered from the Actions tab or via `gh workflow run`

## Test plan
- [ ] Verify workflow appears with "Run workflow" button in Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)