### PR TITLE
fix: resolve golangci-lint issues

### DIFF
--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -108,8 +108,9 @@ func listenLoop(handler http.Handler, initialPort int, restartCh <-chan int) err
 	startServer := func(port int) *http.Server {
 		addr := fmt.Sprintf("127.0.0.1:%d", port)
 		httpSrv := &http.Server{
-			Addr:    addr,
-			Handler: handler,
+			Addr:              addr,
+			Handler:           handler,
+			ReadHeaderTimeout: 10 * time.Second,
 		}
 
 		mu.Lock()

--- a/internal/config/reload.go
+++ b/internal/config/reload.go
@@ -12,13 +12,13 @@ type ConfigManager struct {
 	mu       sync.RWMutex
 	cfg      *Config
 	watcher  *Watcher
-	onChange func(old, new *Config) // optional callback for config changes
+	onChange func(old, updated *Config) // optional callback for config changes
 }
 
 // NewConfigManager creates a ConfigManager, loads the initial config, and
 // starts watching the system and user config files for changes.
 // onChange is called (in a separate goroutine) after a successful reload.
-func NewConfigManager(onChange func(old, new *Config)) (*ConfigManager, error) {
+func NewConfigManager(onChange func(old, updated *Config)) (*ConfigManager, error) {
 	cfg, err := Load()
 	if err != nil {
 		return nil, err

--- a/internal/config/reload_test.go
+++ b/internal/config/reload_test.go
@@ -48,7 +48,7 @@ func TestConfigManagerReloadRetainsOnError(t *testing.T) {
 
 func TestConfigManagerOnChangeCallback(t *testing.T) {
 	callbackCalled := false
-	cm, err := NewConfigManager(func(old, new *Config) {
+	cm, err := NewConfigManager(func(old, updated *Config) {
 		callbackCalled = true
 	})
 	if err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -81,10 +81,11 @@ func TestBroadcastConfigReloaded(t *testing.T) {
 
 	// Connect a WebSocket client to /ws/events.
 	wsURL := "ws" + ts.URL[len("http"):] + "/ws/events"
-	ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	ws, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("failed to connect ws: %v", err)
 	}
+	defer resp.Body.Close()
 	defer ws.Close()
 
 	// Broadcast a config.reloaded event.


### PR DESCRIPTION
## Summary
- Renamed `new` parameter to `updated` in config reload callback to avoid shadowing Go's predeclared `new` identifier (predeclared linter)
- Added `ReadHeaderTimeout: 10s` to `http.Server` in serve command to prevent Slowloris attacks (gosec G112)
- Closed HTTP response body from `websocket.DefaultDialer.Dial` in test (bodyclose linter)

## Test plan
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)