### PR TITLE
ci: run CI checks on staging branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
   pull_request:
-    branches: [main]
+    branches: [main, staging]
   workflow_call:
 
 jobs:


### PR DESCRIPTION
## Summary
- Add `staging` to `push` and `pull_request` branch filters in CI workflow
- PRs targeting `staging` will now trigger the same build, test, and lint checks as `main`

## Test plan
- [ ] Verify this PR itself triggers CI (targets `main`)
- [ ] After merge, open a test PR against `staging` and confirm checks run

🤖 Generated with [Claude Code](https://claude.com/claude-code)