### PR TITLE
fix(web): make main content area scrollable

### DIFF
--- a/web/src/components/Layout.svelte
+++ b/web/src/components/Layout.svelte
@@ -15,5 +15,5 @@
 <style>
   .layout { display: flex; height: 100vh; background: #0f0f1a; }
   .sidebar { width: 260px; border-right: 1px solid #333; overflow-y: auto; background: #1a1a2e; }
-  .content { flex: 1; overflow: hidden; }
+  .content { flex: 1; overflow-y: auto; }
 </style>


### PR DESCRIPTION
## Summary
- Change `overflow: hidden` to `overflow-y: auto` on `.content` in `Layout.svelte`
- The main workspace area was clipping content that exceeded viewport height instead of scrolling

## Test plan
- [ ] Open the dashboard with enough projects/workspaces to exceed viewport height
- [ ] Verify the main content area scrolls while the sidebar scrolls independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)