### PR TITLE
docs: update mkdocs content for clincus

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -205,7 +205,7 @@ internal/
   config/             — config.toml loading, merging, defaults
   container/          — Incus wrapper: launch, stop, delete, exec, mount, snapshot
   session/            — session lifecycle: resolve, setup, cleanup, history, naming
-  tool/               — tool abstraction: claude, opencode, aider, registry
+  tool/               — tool abstraction: claude, copilot, opencode, registry
   image/              — image build: clincus image and custom images
   health/             — health checks for all dependencies
   limits/             — resource limit application via incus CLI

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -117,7 +117,7 @@ Clincus supports multiple AI coding tools. Override the tool for a session:
 
 ```bash
 clincus shell --tool opencode ~/my-project
-clincus shell --tool aider ~/my-project
+clincus shell --tool copilot ~/my-project
 ```
 
 Or set a default in your project config (`.clincus.toml`):

--- a/docs/guides/sessions.md
+++ b/docs/guides/sessions.md
@@ -203,8 +203,8 @@ Run two AI tools on the same project simultaneously:
 # Terminal 1: Claude Code for architecture work
 clincus shell --slot 1 --tool claude ~/my-project
 
-# Terminal 2: Aider for quick edits
-clincus shell --slot 2 --tool aider ~/my-project
+# Terminal 2: opencode for quick edits
+clincus shell --slot 2 --tool opencode ~/my-project
 ```
 
 Both sessions share the same workspace directory on the host; each has its own isolated

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -10,9 +10,8 @@ the project config (`.clincus.toml`), or the user config (`~/.config/clincus/con
 | Tool name | Description | Config mechanism |
 |-----------|-------------|-----------------|
 | `claude` | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `~/.claude/` directory |
-| `opencode` | [opencode](https://github.com/nicholasgasior/opencode) | `~/.opencode.json` file |
 | `copilot` | [GitHub Copilot CLI](https://gh.io/copilot) | `~/.copilot/` directory |
-| `aider` | [Aider](https://aider.chat) | `ANTHROPIC_API_KEY` env var |
+| `opencode` | [opencode](https://github.com/nicholasgasior/opencode) | `~/.opencode.json` file |
 
 ---
 
@@ -24,7 +23,6 @@ the project config (`.clincus.toml`), or the user config (`~/.config/clincus/con
 clincus shell --tool claude ~/my-project
 clincus shell --tool opencode ~/my-project
 clincus shell --tool copilot ~/my-project
-clincus shell --tool aider ~/my-project
 ```
 
 ### Per-project (`.clincus.toml`)
@@ -153,39 +151,11 @@ Clincus copies these files from `~/.copilot/` into the container:
 
 ---
 
-## Aider
-
-Aider uses environment variables for credentials (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.).
-Pass them with the `--env` flag:
-
-```bash
-clincus shell --tool aider --env ANTHROPIC_API_KEY=sk-ant-... ~/my-project
-```
-
-Or set them in the project config so they are applied automatically:
-
-```toml
-# .clincus.toml
-[tool]
-name = "aider"
-```
-
-Then export the key in your shell profile and it will be passed through via `--env`:
-
-```bash
-# In ~/.bashrc or ~/.zshrc
-export ANTHROPIC_API_KEY=sk-ant-...
-```
-
-```bash
-clincus shell --env ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
-```
-
----
-
 ## Custom Tools
 
 You can run any command-line tool in an Incus container by configuring a custom binary name.
+For a tool that does not match any built-in tool name, Clincus falls back to running the
+binary name directly. Session history and config copying will be best-effort.
 
 ```toml
 [tool]
@@ -193,8 +163,29 @@ name = "cursor"
 binary = "cursor-headless"
 ```
 
-For a fully custom tool that does not match any known tool, Clincus falls back to running
-the binary name directly. Session history and config copying will be best-effort.
+### Aider Example
+
+[Aider](https://aider.chat) can be used as a custom tool. It uses environment variables for
+credentials (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.). Pass them with `--env`:
+
+```bash
+clincus shell --tool aider --env ANTHROPIC_API_KEY=sk-ant-... ~/my-project
+```
+
+Or set it in your project config:
+
+```toml
+# .clincus.toml
+[tool]
+name = "aider"
+binary = "aider"
+```
+
+Then pass the API key via `--env`:
+
+```bash
+clincus shell --env ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
+```
 
 ---
 

--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -54,7 +54,7 @@ The main view shows all active Clincus containers with:
 Click **New Session** to open a dialog. Select:
 
 - **Workspace** — choose from your configured workspace roots or type a path
-- **Tool** — Claude Code, opencode, Aider, or any configured tool
+- **Tool** — Claude Code, Copilot, opencode, or any configured tool
 - **Persistent** — toggle persistent mode
 
 The dashboard calls `POST /api/sessions` to create the container and start the tool.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@
 Secure and fast container runtime for AI coding tools on Linux.
 
 Run [Claude Code](https://docs.anthropic.com/en/docs/claude-code),
-[opencode](https://github.com/nicholasgasior/opencode),
-[Aider](https://aider.chat), and other AI assistants in isolated
+[GitHub Copilot CLI](https://gh.io/copilot),
+[opencode](https://github.com/nicholasgasior/opencode), and other AI assistants in isolated
 [Incus](https://linuxcontainers.org/incus/) containers with session
 persistence, a web dashboard, and resource limits.
 
@@ -19,7 +19,7 @@ persistence, a web dashboard, and resource limits.
 | **Container isolation** | Each session runs in its own Incus container, fully isolated from your host |
 | **Session persistence** | Save and resume AI conversations with full history across container restarts |
 | **Web dashboard** | Launch and manage sessions from your browser with a built-in Svelte SPA |
-| **Multi-tool support** | Claude Code, opencode, Aider, and custom tools configurable per project |
+| **Multi-tool support** | Claude Code, GitHub Copilot CLI, opencode, and custom tools configurable per project |
 | **Workspace mounting** | Project files are bind-mounted into containers with UID-shifting for security |
 | **Snapshots** | Checkpoint and rollback container state for safe experimentation |
 | **Resource limits** | CPU, memory, disk I/O, and time limits per session |
@@ -67,7 +67,7 @@ Task-oriented documentation for common workflows.
 - [Sessions](guides/sessions.md) — session lifecycle, persistence, and multi-slot usage
 - [Workspaces](guides/workspaces.md) — workspace mounting and file transfer
 - [Web Dashboard](guides/web-dashboard.md) — browser-based session management
-- [Tools](guides/tools.md) — configuring Claude Code, opencode, Aider, and custom tools
+- [Tools](guides/tools.md) — configuring Claude Code, Copilot, opencode, and custom tools
 - [Images](guides/images.md) — building and customizing container images
 - [Snapshots](guides/snapshots.md) — checkpointing and rolling back container state
 - [Resource Limits](guides/resource-limits.md) — CPU, memory, and time limits

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -69,7 +69,7 @@ Return the list of supported AI tool names.
 **Response:**
 
 ```json
-["claude", "opencode", "aider"]
+["claude", "copilot", "opencode"]
 ```
 
 ---

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -57,7 +57,7 @@ use `--background` to run detached.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--tool` | (from config) | AI tool to run: `claude`, `opencode`, `aider` |
+| `--tool` | (from config) | AI tool to run: `claude`, `copilot`, `opencode` |
 | `--debug` | `false` | Launch bash instead of the AI tool (for debugging) |
 | `--background` | `false` | Run the AI tool in a detached background tmux session |
 | `--tmux` | `true` | Use tmux for session management |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -134,7 +134,7 @@ auto_stop = true
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `name` | string | `"claude"` | Tool to run: `claude`, `opencode`, `aider` |
+| `name` | string | `"claude"` | Tool to run: `claude`, `copilot`, `opencode` |
 | `binary` | string | `""` | Override binary path (empty = use tool default) |
 
 ### `[tool.claude]`


### PR DESCRIPTION
## Summary

Update documentation across the site to reflect the current set of built-in AI tools. Aider has been moved from a built-in tool to a custom tool example, and GitHub Copilot CLI has been added as a first-class supported tool. Tool listing order is now consistently claude, copilot, opencode throughout.

## Changes

- Added GitHub Copilot CLI as a built-in tool in all reference pages, guides, and the landing page
- Moved Aider from built-in tool to a "Custom Tools" example, with updated configuration showing the `binary` field
- Reordered tool listings to consistent claude → copilot → opencode across CLI reference, config reference, API reference, quickstart, and architecture overview
- Updated web dashboard docs to reflect the new tool picker options
- Consolidated the "Custom Tools" and "Aider" sections in the tools guide into a single section with Aider as an example of custom tool configuration