### PR TITLE
docs: update documentation for clincus

### DIFF
--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -1,0 +1,143 @@
+# Clincus — Developer Documentation
+
+## Purpose
+
+Clincus is a CLI tool and web dashboard for running AI coding sessions (Claude, Copilot, Opencode) inside isolated Incus containers. It handles container lifecycle, workspace mounting, session persistence, resource limits, and provides both a Cobra-based CLI and a Svelte 5 web dashboard for managing sessions.
+
+Derived from [code-on-incus](https://github.com/mensfeld/code-on-incus). Web dashboard inspired by [wingthing](https://github.com/ehrlich-b/wingthing).
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  User Interface                                         │
+│  ┌──────────────┐  ┌────────────────────────────────┐   │
+│  │  CLI (Cobra)  │  │  Web Dashboard (Svelte 5)      │   │
+│  │  cmd/clincus/ │  │  web/ → webui/ (go:embed)      │   │
+│  └──────┬───────┘  └──────────────┬─────────────────┘   │
+│         │                         │                      │
+│  ┌──────┴───────┐  ┌─────────────┴──────────────────┐   │
+│  │ internal/cli/ │  │ internal/server/               │   │
+│  │ 23 commands   │  │ REST API + WebSocket + Bridge  │   │
+│  └──────┬───────┘  └──────────────┬─────────────────┘   │
+│         │                         │                      │
+│  ┌──────┴─────────────────────────┴─────────────────┐   │
+│  │  Core Packages                                    │   │
+│  │  ┌────────────┐ ┌──────────┐ ┌────────────────┐  │   │
+│  │  │ session/   │ │ config/  │ │ container/     │  │   │
+│  │  │ lifecycle  │ │ TOML +   │ │ Incus mgmt    │  │   │
+│  │  │ + naming   │ │ reload   │ │ + commands     │  │   │
+│  │  └────────────┘ └──────────┘ └────────────────┘  │   │
+│  │  ┌────────────┐ ┌──────────┐ ┌────────────────┐  │   │
+│  │  │ tool/      │ │ limits/  │ │ image/         │  │   │
+│  │  │ AI tool    │ │ CPU/mem/ │ │ builder +      │  │   │
+│  │  │ abstraction│ │ disk/run │ │ versioning     │  │   │
+│  │  └────────────┘ └──────────┘ └────────────────┘  │   │
+│  │  ┌────────────┐ ┌──────────┐ ┌────────────────┐  │   │
+│  │  │ terminal/  │ │ health/  │ │ cleanup/       │  │   │
+│  │  │ TERM + PTY │ │ checks   │ │ orphan detect  │  │   │
+│  │  └────────────┘ └──────────┘ └────────────────┘  │   │
+│  └──────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────┘
+                          │
+                    ┌─────┴─────┐
+                    │   Incus   │
+                    │ Containers│
+                    └───────────┘
+```
+
+### Package Responsibilities
+
+| Package | Path | Role |
+|---------|------|------|
+| **cli** | `internal/cli/` | 23 Cobra commands with global flags for workspace, slot, image, limits |
+| **server** | `internal/server/` | HTTP API, WebSocket terminal/shell/events, PTY bridge |
+| **session** | `internal/session/` | Setup (11-step flow), cleanup, naming, history, persistence |
+| **container** | `internal/container/` | Incus operations: launch, exec, mount, snapshot, file transfer |
+| **config** | `internal/config/` | TOML loading (system→user→project→env), hot-reload, profiles |
+| **tool** | `internal/tool/` | AI tool interface: Claude, Copilot, Opencode with config injection |
+| **limits** | `internal/limits/` | Resource limits: CPU, memory, disk, processes, duration timeout |
+| **image** | `internal/image/` | Image building with versioning, network waits, DNS fixes |
+| **terminal** | `internal/terminal/` | TERM sanitization (exotic → xterm-256color) |
+| **health** | `internal/health/` | System checks: Incus, storage, network, permissions |
+| **cleanup** | `internal/cleanup/` | Orphan detection (placeholder, not yet implemented) |
+| **webui** | `webui/` | `go:embed` wrapper for built Svelte frontend assets |
+
+## Key Patterns
+
+### Session Naming & Slot Allocation
+
+Container names follow `<prefix><workspace-hash>-<slot>`:
+- Prefix: `clincus-` (configurable via `CLINCUS_CONTAINER_PREFIX`)
+- Hash: first 8 chars of SHA256 of absolute workspace path
+- Slot: integer 1-10, auto-allocated to first available
+
+### Session Setup Flow (11 Steps)
+
+1. Generate/resolve container name from workspace hash
+2. Determine image (default: "clincus")
+3. Determine exec context (non-root for clincus image, root otherwise)
+4. Check for existing container to reuse
+5. Create container: UID mapping, workspace mount, tmpfs, additional mounts, security mounts, resource limits, start
+6. Wait for readiness, set metadata labels
+7. Start timeout monitor if `max_duration` configured
+8. _(reserved)_
+9. Restore session data if resuming
+10. _(workspace already mounted in step 5)_
+11. Setup CLI tool config (credentials injection, settings merge)
+
+### Tool Abstraction
+
+Tools implement a `Tool` interface with optional capabilities:
+
+| Tool | Config Type | Resume Support | Config Location |
+|------|------------|----------------|-----------------|
+| Claude | Directory-based | Yes (JSONL discovery) | `~/.claude/` |
+| Copilot | Directory-based | No | `~/.copilot/` |
+| Opencode | File-based | No (SQLite) | `~/.opencode.json` |
+
+All tools run inside tmux sessions for monitoring and reattachment. Credentials are injected fresh on resume.
+
+### Security Model
+
+- **UID shifting**: Bind mounts use Incus UID/GID shifting (disabled for Colima/Lima)
+- **Protected paths**: `.git/hooks`, `.git/config`, `.husky`, `.vscode` mounted read-only
+- **Symlink rejection**: Protected path setup refuses symlinks
+- **File API**: Path traversal prevention, 5MB size limit, binary detection
+
+### Config Hierarchy (Lowest → Highest Precedence)
+
+1. Built-in defaults
+2. System: `/etc/clincus/config.toml`
+3. User: `~/.config/clincus/config.toml`
+4. Project: `./.clincus.toml`
+5. Environment variables (`CLINCUS_*`)
+6. CLI flags
+
+Config supports hot-reload via file watcher with 1-second debounce. Failed reloads retain previous valid config.
+
+### Web Dashboard Architecture
+
+- **Backend**: Go HTTP server with REST API + 3 WebSocket endpoints
+- **Frontend**: Svelte 5 SPA with hash routing, xterm.js terminals, Monaco editor
+- **Terminal bridge**: PTY ↔ WebSocket relay via `creack/pty`
+- **Events**: Incus lifecycle monitoring (`incus monitor`) broadcasts session.started/stopped
+- **Assets**: Embedded via `go:embed` from `webui/dist/`
+
+### Build Pipeline
+
+- `make web` builds Svelte frontend → `webui/dist/`
+- `make build` compiles Go binary with embedded frontend + version ldflags
+- GoReleaser Pro produces Linux/Darwin binaries + deb/rpm/apk packages
+- Cosign signs all release artifacts
+
+## Configuration Reference
+
+See [configuration.md](configuration.md) for the complete config reference with all TOML fields, defaults, environment variables, and profiles.
+
+## Detailed Documentation
+
+- [CLI Commands](cli-commands.md) — All 23 commands with flags and behavior
+- [Web Dashboard & API](web-dashboard.md) — REST API, WebSocket protocol, frontend architecture
+- [Session Lifecycle](session-lifecycle.md) — Setup flow, persistence, cleanup, naming
+- [Configuration](configuration.md) — Complete TOML reference with defaults and env vars

--- a/yeti/cli-commands.md
+++ b/yeti/cli-commands.md
@@ -1,0 +1,254 @@
+# CLI Commands Reference
+
+All commands are defined in `internal/cli/`. The root command (`clincus`) defaults to `shell` when no subcommand is given.
+
+## Global Flags
+
+Available on all commands (defined in `internal/cli/root.go`):
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--workspace`, `-w` | string | `.` | Workspace directory to mount |
+| `--slot` | int | 0 | Slot number (0 = auto-allocate) |
+| `--image` | string | config | Custom container image |
+| `--persistent` | bool | false | Reuse container across sessions |
+| `--resume` | string | `auto` | Resume from session ID |
+| `--continue` | string | `auto` | Alias for `--resume` |
+| `--profile` | string | | Named config profile |
+| `--env`, `-e` | []string | | Environment variables (KEY=VALUE) |
+| `--mount` | []string | | Mount directories (HOST:CONTAINER) |
+| `--writable-git-hooks` | bool | false | Allow writes to .git/hooks |
+
+### Resource Limit Flags (Global)
+
+| Flag | Example |
+|------|---------|
+| `--limit-cpu` | `2`, `0-3`, `0,1,3` |
+| `--limit-cpu-allowance` | `50%`, `25ms/100ms` |
+| `--limit-cpu-priority` | `0`-`10` |
+| `--limit-memory` | `2GiB`, `512MiB`, `50%` |
+| `--limit-memory-swap` | `true`, `false`, size |
+| `--limit-memory-enforce` | `hard`, `soft` |
+| `--limit-disk-read` | `10MiB/s`, `1000iops` |
+| `--limit-disk-write` | `5MiB/s`, `1000iops` |
+| `--limit-disk-max` | Combined I/O limit |
+| `--limit-disk-priority` | `0`-`10` |
+| `--limit-processes` | 0 = unlimited |
+| `--limit-duration` | `2h`, `30m`, `1h30m` |
+
+## Commands
+
+### shell (default)
+
+Start an interactive AI coding session. All sessions run in tmux.
+
+```
+clincus [shell] [flags]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--debug` | false | Launch bash instead of AI tool |
+| `--background` | false | Run detached tmux session |
+| `--tmux` | true | Use tmux (always true) |
+| `--container` | | Use existing container |
+| `--tool` | config | Override AI tool |
+
+Calls: `session.Resolve` → `session.Setup` → tmux launch → `session.Cleanup`
+
+### run
+
+Run a command in an ephemeral container.
+
+```
+clincus run [flags] -- <command>
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--capture` | false | Capture output instead of streaming |
+| `--timeout` | 120 | Command timeout (seconds) |
+| `--format` | pretty | Output format (pretty\|json) |
+
+### list
+
+List active containers and saved sessions.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--all` | false | Include saved sessions |
+| `--format` | text | Output format (text\|json) |
+
+### attach
+
+Attach to a running session. Auto-attaches if only one session active.
+
+```
+clincus attach [container-name] [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--bash` | Attach to bash instead of tmux |
+| `--slot` | Slot number (requires workspace context) |
+
+### info
+
+Show session details: ID, container, data size, resume command.
+
+```
+clincus info [session-id]
+```
+
+### build
+
+Build Incus image for AI coding sessions.
+
+```
+clincus build [--force]
+clincus build custom <name> --script <path> [--base clincus] [--force]
+```
+
+### image
+
+Image management subcommands:
+
+| Subcommand | Description |
+|------------|-------------|
+| `image list [--all] [--prefix X]` | List images (table\|json) |
+| `image publish <container> <alias>` | Publish container as image |
+| `image delete <alias>` | Delete image |
+| `image exists <alias>` | Exit 0 if exists |
+| `image cleanup <prefix> --keep N` | Delete old versioned images |
+
+### container
+
+Low-level container operations:
+
+| Subcommand | Description |
+|------------|-------------|
+| `container launch <image> <name> [--ephemeral]` | Create container |
+| `container start <name>` | Start container |
+| `container stop <name> [--force]` | Stop container |
+| `container delete <name> [--force]` | Delete container |
+| `container exec <name> -- <cmd> [--user N --group N --env K=V --cwd X --capture --tty]` | Execute command |
+| `container exists <name>` | Exit 0 if exists |
+| `container running <name>` | Exit 0 if running |
+| `container mount <name> <device> <source> <path> [--shift --readonly]` | Add mount |
+| `container list [--format text\|json]` | List containers |
+
+Note: `--tty` and `--capture` are mutually exclusive on `container exec`.
+
+### file
+
+File transfer operations:
+
+| Subcommand | Description |
+|------------|-------------|
+| `file push <local> <container>:<remote> [-r]` | Upload file/dir |
+| `file pull <container>:<remote> <local> [-r]` | Download file/dir |
+
+### snapshot
+
+Container snapshot management. Container auto-detected from workspace unless `--container` specified.
+
+| Subcommand | Description |
+|------------|-------------|
+| `snapshot create [name] [--stateful]` | Create snapshot |
+| `snapshot list [--all] [--format text\|json]` | List snapshots |
+| `snapshot restore <name> [--stateful --force]` | Restore (container must be stopped) |
+| `snapshot delete [name] [--all --force]` | Delete snapshot(s) |
+| `snapshot info <name> [--format text\|json]` | Snapshot details |
+
+Container resolution: `--container` flag → `CLINCUS_CONTAINER` env → workspace auto-detect.
+
+### tmux
+
+Interact with tmux sessions in containers:
+
+| Subcommand | Description |
+|------------|-------------|
+| `tmux send <session> <command>` | Send command to session |
+| `tmux capture <session>` | Capture pane output |
+| `tmux list` | List active tmux sessions |
+
+### clean
+
+Cleanup resources.
+
+| Flag | Description |
+|------|-------------|
+| `--all` | Clean containers + sessions + orphans |
+| `--sessions` | Clean saved session data |
+| `--orphans` | Clean orphaned stopped containers |
+| `--force` | Skip confirmation |
+| `--dry-run` | Show what would be cleaned |
+
+### kill
+
+Force stop and delete containers immediately.
+
+```
+clincus kill [container...] [--all --force]
+```
+
+### shutdown
+
+Graceful stop and delete with timeout.
+
+```
+clincus shutdown [container...] [--all --force --timeout 60]
+```
+
+### resume
+
+Resume frozen (paused) containers.
+
+```
+clincus resume [container-name]
+```
+
+### persist
+
+Convert ephemeral sessions to persistent.
+
+```
+clincus persist [container...] [--all --force]
+```
+
+### serve
+
+Start web dashboard.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--port` | 3000 | Listen port |
+| `--open` | false | Open browser |
+
+### health
+
+Check system health. Exit codes: 0=healthy, 1=degraded, 2=unhealthy.
+
+| Flag | Description |
+|------|-------------|
+| `--format` | text\|json |
+| `--verbose` | Include additional checks |
+
+Checks: OS, Incus, permissions, image, storage, disk space, config, tool, DNS, sudo.
+
+### service
+
+Manage systemd user service:
+
+| Subcommand | Description |
+|------------|-------------|
+| `service install` | Write unit file, enable |
+| `service start` | Start service |
+| `service stop` | Stop service |
+| `service remove` | Stop, disable, remove unit |
+
+Unit path: `~/.config/systemd/user/clincus.service`
+
+### version
+
+Print version info: `clincus {Version} (commit: {Commit}, built: {Date})`

--- a/yeti/configuration.md
+++ b/yeti/configuration.md
@@ -1,0 +1,163 @@
+# Configuration Reference
+
+Configuration is loaded by `internal/config/loader.go` with hot-reload support via `internal/config/reload.go`.
+
+## Config File Locations (Precedence Low → High)
+
+1. **System**: `/etc/clincus/config.toml`
+2. **User**: `~/.config/clincus/config.toml`
+3. **Project**: `./.clincus.toml` (current working directory)
+4. **Env override**: `CLINCUS_CONFIG` points to a specific file
+
+All files are TOML format. Higher precedence overrides lower.
+
+## Config Sections
+
+### [defaults]
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `image` | string | `"clincus"` | Default container image |
+| `persistent` | bool | `false` | Reuse containers by default |
+| `model` | string | `"claude-sonnet-4-5"` | AI model |
+
+### [paths]
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `sessions_dir` | string | `~/.clincus/sessions` | Saved session storage |
+| `storage_dir` | string | `~/.clincus/storage` | General storage |
+| `logs_dir` | string | `~/.clincus/logs` | Logs directory |
+| `preserve_workspace_path` | bool | `false` | Mount workspace at same host path instead of `/workspace` |
+
+### [incus]
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `project` | string | `"default"` | Incus project name |
+| `group` | string | `"incus-admin"` | User group for Incus access |
+| `code_uid` | int | `1000` | UID for code user in container |
+| `code_user` | string | `"code"` | Username in container |
+| `disable_shift` | bool | `false` | Disable UID/GID shifting (for Colima/Lima) |
+
+### [tool]
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | string | `"claude"` | Tool: `claude`, `copilot`, `opencode` |
+| `binary` | string | `""` | Binary path override (empty = tool default) |
+
+#### [tool.claude]
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `effort_level` | string | `"medium"` | Effort level: `low`, `medium`, `high` |
+
+### [[mounts.default]]
+
+Array of additional mount entries:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `host` | string | Host path (supports `~` expansion) |
+| `container` | string | Container path (must be absolute) |
+
+### [git]
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `writable_hooks` | bool | `false` | Allow container writes to .git/hooks |
+
+### [security]
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `protected_paths` | []string | `[".git/hooks", ".git/config", ".husky", ".vscode"]` | Paths mounted read-only |
+| `additional_protected_paths` | []string | `[]` | Extra paths to protect |
+| `disable_protection` | bool | `false` | Disable all read-only protection |
+
+### [limits]
+
+#### [limits.cpu]
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `count` | string | `""` | CPU count: `"2"`, `"0-3"`, `"0,1,3"` |
+| `allowance` | string | `""` | `"50%"`, `"25ms/100ms"` |
+| `priority` | int | `0` | Priority 0-10 |
+
+#### [limits.memory]
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `limit` | string | `""` | `"512MiB"`, `"2GiB"`, `"50%"` |
+| `enforce` | string | `"soft"` | `"hard"` or `"soft"` |
+| `swap` | string | `"true"` | `"true"`, `"false"`, or size |
+
+#### [limits.disk]
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `read` | string | `""` | `"10MiB/s"`, `"1000iops"` |
+| `write` | string | `""` | `"5MiB/s"`, `"1000iops"` |
+| `max` | string | `""` | Combined read+write limit |
+| `priority` | int | `0` | Priority 0-10 |
+| `tmpfs_size` | string | `""` | `/tmp` size: `"2GiB"` (empty = root disk) |
+
+#### [limits.runtime]
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_duration` | string | `""` | `"2h"`, `"30m"`, `"1h30m"` |
+| `max_processes` | int | `0` | Process limit (0 = unlimited) |
+| `auto_stop` | bool | `true` | Stop container when limit reached |
+| `stop_graceful` | bool | `true` | Graceful vs force stop |
+
+### [dashboard]
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `port` | int | `3000` | Dashboard listen port |
+| `workspace_roots` | []string | `[]` | Workspace root directories |
+
+### [profiles.\<name\>]
+
+Named configuration profiles applied via `--profile` flag.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `image` | string | Override default image |
+| `environment` | map[string]string | Environment variables |
+| `persistent` | bool | Override persistent mode |
+| `limits` | LimitsConfig | Override resource limits |
+
+## Environment Variables
+
+| Variable | Maps To |
+|----------|---------|
+| `CLINCUS_CONFIG` | Config file path (highest priority) |
+| `CLINCUS_IMAGE` | `defaults.image` |
+| `CLINCUS_SESSIONS_DIR` | `paths.sessions_dir` |
+| `CLINCUS_STORAGE_DIR` | `paths.storage_dir` |
+| `CLINCUS_PERSISTENT` | `defaults.persistent` (`true` or `1`) |
+| `CLINCUS_LIMIT_CPU` | `limits.cpu.count` |
+| `CLINCUS_LIMIT_CPU_ALLOWANCE` | `limits.cpu.allowance` |
+| `CLINCUS_LIMIT_MEMORY` | `limits.memory.limit` |
+| `CLINCUS_LIMIT_MEMORY_SWAP` | `limits.memory.swap` |
+| `CLINCUS_LIMIT_DISK_READ` | `limits.disk.read` |
+| `CLINCUS_LIMIT_DISK_WRITE` | `limits.disk.write` |
+| `CLINCUS_LIMIT_DURATION` | `limits.runtime.max_duration` |
+| `CLINCUS_CONTAINER_PREFIX` | Container name prefix (for listing/detection) |
+| `CLINCUS_CONTAINER` | Specific container name (for snapshot ops) |
+
+## Hot-Reload
+
+The `ConfigManager` (`internal/config/reload.go`) watches system and user config files:
+
+1. Uses `fsnotify` to watch for file changes
+2. 1-second debounce before reload
+3. `onChange` callback fires on successful reload
+4. Failed reloads retain previous valid config
+5. Watcher failure is non-fatal (server continues with last config)
+
+Used by the web dashboard server to dynamically update port and workspace roots.

--- a/yeti/session-lifecycle.md
+++ b/yeti/session-lifecycle.md
@@ -1,0 +1,161 @@
+# Session Lifecycle
+
+Sessions are the core abstraction in clincus. Each session represents an AI coding tool running inside an Incus container with a mounted workspace.
+
+## Naming Convention
+
+Container name format: `<prefix><workspace-hash>-<slot>`
+
+- **Prefix**: `clincus-` (configurable via `CLINCUS_CONTAINER_PREFIX`)
+- **Hash**: First 8 characters of SHA256 of the absolute workspace path
+- **Slot**: Integer 1-10, auto-allocated to first available
+
+Example: workspace `/home/user/myproject` → container `clincus-a1b2c3d4-1`
+
+Functions in `internal/session/naming.go`:
+- `ContainerName(workspace, slot)` — generate name
+- `WorkspaceHash(path)` — SHA256 first 8 chars
+- `AllocateSlot()` — find first available slot (1-10)
+- `ParseContainerName()` — extract hash and slot
+- `ListWorkspaceSessions()` — all slots for a workspace
+
+## Session Setup (11 Steps)
+
+Defined across `internal/session/setup.go` and helper files.
+
+### Phase 1: Resolution (`resolveContainer`)
+
+1. **Generate container name** from workspace path hash + slot
+2. **Determine image** — default "clincus", overridable by flag/config
+3. **Determine exec context** — non-root user (`code`, UID 1000) for clincus image, root for others
+
+### Phase 2: Container Creation (`createAndConfigureContainer`)
+
+4. **Check for existing container** — reuse if persistent and already running
+5. **Create and configure container**:
+   - UID/GID mapping: `shift=true` for local, `raw.idmap` for CI, disabled for Colima/Lima
+   - Mount workspace as disk device at `/workspace` (or preserved host path if `preserve_workspace_path=true`)
+   - Configure `/tmp` tmpfs size if set
+   - Mount additional directories from config `[mounts.default]`
+   - Mount security paths read-only (`.git/hooks`, `.git/config`, `.husky`, `.vscode`)
+   - Apply resource limits via `limits.ApplyResourceLimits()`
+   - Start container
+
+### Phase 3: Post-Launch (`postLaunchSetup`)
+
+6. **Wait for readiness** — poll until container responds, set metadata labels
+7. **Start timeout monitor** — background goroutine if `max_duration` configured
+
+### Phase 4: Tool Configuration (`configureToolAccess`)
+
+9. **Restore session data** if resuming (non-persistent sessions): pull tool config from saved session directory
+10. _(workspace already mounted in step 5)_
+11. **Setup CLI tool config**:
+    - **Directory-based tools** (Claude, Copilot): Copy config directory, inject credentials, merge settings
+    - **File-based tools** (Opencode): Write single config file to container home
+    - **ENV-based tools**: No file config needed
+    - Path rewriting: host home paths → container home paths
+    - Settings merge: Python JSON manipulation for safe `.claude/settings.json` injection
+
+## Tool Configuration Details
+
+### Claude (`internal/tool/tool.go`)
+
+- Config dir: `~/.claude/`
+- Sessions dir: `~/.clincus/sessions-claude/`
+- Resume: discovers `.jsonl` files in `projects/-workspace/`
+- Command: `claude --verbose --permission-mode bypassPermissions --session-id <id>`
+- Sandbox settings injected into `settings.json` with effort level
+- Essential files: `.credentials.json`, `config.yml`, `settings.json`, `plugins/`, `hooks/`
+- Auto-env: `GH_TOKEN`
+
+### Copilot (`internal/tool/copilot.go`)
+
+- Config dir: `~/.copilot/`
+- Command: `copilot --allow-all-tools`
+- No CLI resume support
+- Essential files: `config.json`, `mcp-config.json`, `agents/`
+- Auto-env: `GH_TOKEN`
+
+### Opencode (`internal/tool/opencode.go`)
+
+- Config file: `~/.opencode.json` (file-based, not directory)
+- Command: `opencode` (always fresh session)
+- No CLI resume (SQLite-based)
+- Sandbox: `{ "permission": { "*": "allow" } }`
+
+### GitHub Token Resolution (`internal/tool/github.go`)
+
+Priority: `GH_TOKEN` env → `GITHUB_TOKEN` env → `gh auth token` CLI → empty
+
+## Session Persistence
+
+### Persistent Mode (`--persistent`)
+
+- Container kept running after session ends
+- Reused on next session start for same workspace+slot
+- Tool state lives in the running container
+
+### Non-Persistent Mode (Default)
+
+- On cleanup: tool config pulled to `~/.clincus/sessions-<tool>/<session-id>/`
+- Container deleted after stop
+- On resume: session data restored from saved directory, fresh credentials injected
+
+### Session Metadata
+
+Stored in `~/.clincus/sessions-<tool>/<session-id>/metadata.json`:
+```json
+{
+  "id": "uuid",
+  "container": "clincus-a1b2c3d4-1",
+  "workspace": "/home/user/project",
+  "persistent": false,
+  "saved_at": "2026-03-22T10:00:00Z"
+}
+```
+
+## Cleanup (`internal/session/cleanup.go`)
+
+1. Save session data (pull tool config directory to local storage)
+2. Check container status with exponential backoff (detect shutdown completion)
+3. **Persistent**: keep container running
+4. **Non-persistent**: delete if stopped; keep if still running (for re-attach)
+5. Record stop in history
+
+## History (`internal/session/history.go`)
+
+- JSONL-based append-only log at `~/.clincus/history.jsonl`
+- Records: `RecordStart(id, workspace, tool, persistent)`, `RecordStop(id, exitCode)`
+- File locking prevents concurrent writes
+- `ListHistory()` merges start/stop records, returns newest first
+
+## Mount Strategy
+
+| Mount Type | Source | Target | Shift | Read-Only |
+|------------|--------|--------|-------|-----------|
+| Workspace | Host workspace dir | `/workspace` or preserved path | Yes | No |
+| Config mounts | `[mounts.default]` entries | Specified container path | Yes | No |
+| Security mounts | `.git/hooks`, `.vscode`, etc. | Same relative path | Yes | **Yes** |
+| CLI flag mounts | `--mount HOST:CONTAINER` | Specified container path | Yes | No |
+
+### Security Protections
+
+- Protected paths from config `[security]`: `.git/hooks`, `.git/config`, `.husky`, `.vscode`
+- Symlink detection: refuses to mount symlinks as protected paths
+- `--writable-git-hooks` flag overrides `.git/hooks` protection
+- Additional paths via `[security].additional_protected_paths`
+- All protection disableable via `[security].disable_protection`
+
+## Resource Limits (`internal/limits/`)
+
+Applied via Incus config keys before container start.
+
+| Category | Config Keys | Validation |
+|----------|-------------|------------|
+| CPU | `limits.cpu`, `limits.cpu.allowance`, `limits.cpu.priority` | Regex: count, range, list, percentage, time slice |
+| Memory | `limits.memory`, `limits.memory.enforce`, `limits.memory.swap` | Size or percentage |
+| Disk | `limits.read`, `limits.write`, `limits.max`, `limits.disk.priority` | Rate or IOPS |
+| Runtime | `limits.processes` + `TimeoutMonitor` goroutine | Duration parsing |
+
+`TimeoutMonitor` runs as a background goroutine with context cancellation. When duration expires, stops container (gracefully or forcefully based on config).

--- a/yeti/web-dashboard.md
+++ b/yeti/web-dashboard.md
@@ -1,0 +1,157 @@
+# Web Dashboard & API
+
+The web dashboard provides a browser-based interface for managing AI coding sessions. Backend is in `internal/server/`, frontend in `web/`, embedded via `webui/`.
+
+## REST API
+
+### Session Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/sessions` | List running sessions with container metadata |
+| POST | `/api/sessions` | Create session (body: workspace, tool, persistent) |
+| DELETE | `/api/sessions/{id}` | Stop session (`?force=true` to kill) |
+| POST | `/api/sessions/{id}/resume` | Resume stopped persistent session |
+| GET | `/api/sessions/history` | Session history (query: limit, offset) |
+
+### Workspace Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/workspaces` | List workspaces from configured roots |
+| POST | `/api/workspaces` | Add workspace root |
+| DELETE | `/api/workspaces?path=...` | Remove workspace root |
+| POST | `/api/workspaces/folder` | Create project folder in a root |
+
+### Config Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/config` | Get full config |
+| PUT | `/api/config` | Update config (port, workspace roots) |
+| GET | `/api/tools` | List supported tools |
+
+### File Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/sessions/{id}/files?path=...` | List directory contents |
+| GET | `/api/sessions/{id}/files/content?path=...` | Read file (max 5MB) |
+| PUT | `/api/sessions/{id}/files/content?path=...` | Write file |
+
+File security: path traversal rejected, binary detection (null byte in first 512 bytes), operations run as `CodeUID` (1000).
+
+## WebSocket Endpoints
+
+### Terminal (`/ws/terminal/{id}`)
+
+Connects to the tmux session running the AI tool inside the container.
+
+Flow:
+1. Validates container is running
+2. Executes: `incus exec --force-interactive --env TERM=xterm-256color <container> -- tmux attach-session -t clincus-<id>`
+3. PTY ↔ WebSocket bridge via `creack/pty` (16KB read buffer)
+
+### Shell (`/ws/shell/{id}`)
+
+Independent bash shell in the container (separate from tmux).
+
+Flow:
+1. Launches: `bash --login -c "cd <workspace> && exec bash --login"`
+2. Sets HOME and TERM env vars
+3. Same PTY bridge as terminal
+
+### Events (`/ws/events`)
+
+Persistent event stream for real-time updates.
+
+- Server watches `incus monitor --type lifecycle --format json`
+- Broadcasts: `session.started`, `session.stopped`, `config.reloaded`
+- Client auto-reconnects with exponential backoff (2s → 4s → 8s → 30s max)
+- On reconnect, frontend refetches all state
+
+### WebSocket Message Protocol
+
+```json
+{
+  "type": "output|input|resize|exit|error",
+  "data": "terminal content or input",
+  "cols": 80,
+  "rows": 24,
+  "code": 0,
+  "message": "error description"
+}
+```
+
+| Type | Direction | Purpose |
+|------|-----------|---------|
+| `output` | Server→Client | Terminal data from PTY |
+| `input` | Client→Server | Keyboard input |
+| `resize` | Client→Server | Terminal dimensions changed |
+| `exit` | Server→Client | Process exited with code |
+| `error` | Server→Client | Error notification |
+
+## Frontend Architecture
+
+### Tech Stack
+
+- **Framework**: Svelte 5 (runes-based reactivity)
+- **Terminal**: xterm.js 6.0 with fit addon
+- **Editor**: Monaco Editor 0.55
+- **Bundler**: Vite 6
+- **Routing**: Hash-based (`#/`, `#/dashboard`, `#/terminal/{id}`, `#/settings`)
+
+### Component Hierarchy
+
+```
+App.svelte (router + event subscription)
+├── Layout.svelte (sidebar + main content)
+│   ├── SessionList.svelte (sidebar session cards)
+│   │   └── SessionCard.svelte (stop/kill/detach actions)
+│   ├── Dashboard.svelte (workspace grid)
+│   │   ├── WorkspaceCard.svelte (project cards)
+│   │   ├── LaunchDialog.svelte (create session modal)
+│   │   └── NewFolderDialog.svelte
+│   ├── SessionView.svelte (tabbed view)
+│   │   ├── TabBar.svelte (Terminal/Shell/Editor tabs)
+│   │   ├── TerminalPane.svelte (xterm.js → /ws/terminal)
+│   │   ├── ShellPane.svelte (xterm.js → /ws/shell + restart)
+│   │   └── EditorPane.svelte
+│   │       ├── FileTree.svelte (lazy-loaded tree)
+│   │       └── MonacoEditor.svelte (syntax highlighting)
+│   └── Settings.svelte (config UI)
+```
+
+### State Management (Svelte Stores)
+
+| Store | File | State |
+|-------|------|-------|
+| Sessions | `stores/sessions.svelte.ts` | Active sessions array |
+| Workspaces | `stores/workspaces.svelte.ts` | Workspaces, roots, expanded state |
+| Config | `stores/config.svelte.ts` | Full ClincusConfig mirror |
+
+### API Client (`lib/api.ts`)
+
+Retry strategy: exponential backoff 1s→2s→4s, max 3 retries. Retries on network errors and 5xx. 4xx thrown immediately.
+
+### Terminal Configuration
+
+- Font: 14px JetBrains Mono
+- Theme: Dark (#1a1a2e background), 256-color
+- Cursor blink enabled
+- FitAddon for responsive sizing
+- Lazy initialization (only when pane visible)
+
+## Config Hot-Reload
+
+1. `ConfigManager` watches system and user config files (`fsnotify`)
+2. 1-second debounce, failed reloads retain previous config
+3. Server broadcasts `config.reloaded` via WebSocket events
+4. Frontend refetches config + workspaces on event receipt
+
+## Session Container Metadata
+
+Sessions stored as Incus container config keys:
+- `user.clincus.workspace` — workspace path
+- `user.clincus.tool` — tool name
+- `user.clincus.persistent` — boolean flag


### PR DESCRIPTION
## Summary

Add comprehensive developer documentation covering the project's architecture, CLI commands, configuration reference, session lifecycle, and web dashboard API. These docs provide a detailed internal reference for contributors and maintainers, complementing the existing MkDocs user-facing documentation.

## Changes

- **New `yeti/OVERVIEW.md`**: Architecture diagram, package responsibility table, key patterns (session naming, setup flow, tool abstraction, security model, config hierarchy, build pipeline)
- **New `yeti/cli-commands.md`**: Complete reference for all 23 CLI commands with flags, defaults, and usage examples
- **New `yeti/configuration.md`**: Full TOML config reference covering all sections, fields, defaults, environment variable mappings, and hot-reload behavior
- **New `yeti/session-lifecycle.md`**: Session naming, 11-step setup flow, tool configuration details, persistence model, cleanup, history, mount strategy, and resource limits
- **New `yeti/web-dashboard.md`**: REST API endpoints (sessions, workspaces, config, files) and WebSocket protocol documentation