### PR TITLE
docs: update documentation for clincus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,3 +137,8 @@ git push origin v0.x.0  # Triggers GoReleaser release workflow
 - The `webui/dist/` directory needs a `.gitkeep` for `go:embed` — `make clean` removes built assets but the `.gitkeep` must remain tracked
 - The `.gitignore` uses `/clincus` (with leading slash) to only ignore the binary at root, not the `cmd/clincus/` directory
 - Do NOT rename `incus monitor` in `internal/server/ws_events.go` — that's the Incus CLI lifecycle monitoring command, not a clincus feature
+## Documentation
+
+**update documentation** After any change to source code, update relevant documentation in CLAUDE.md, README.md and the yeti/ folder. A task is not complete without reviewing and updating relevant documentation.
+
+**yeti/ directory** The `yeti/` directory contains documentation written for AI consumption and context enhancement, not primarily for humans. Jobs like `doc-maintainer` and `issue-worker` instruct the AI to read `yeti/OVERVIEW.md` and related files for codebase context before performing tasks. Write content in this directory to be maximally useful to an AI agent understanding the codebase — detailed architecture, patterns, and decision rationale rather than user-facing guides.


### PR DESCRIPTION
## Summary

Adds explicit documentation guidelines to CLAUDE.md to ensure AI agents consistently update documentation alongside code changes. This codifies the expectation that tasks are not complete without reviewing and updating relevant docs, and clarifies the purpose of the `yeti/` directory as AI-oriented context documentation.

## Changes

- Added a **Documentation** section to CLAUDE.md with two guidelines:
  - A requirement to update CLAUDE.md, README.md, and `yeti/` docs after any source code change
  - A description of the `yeti/` directory's purpose as AI-consumption documentation, distinct from user-facing guides